### PR TITLE
If tlsext ticket decrypt callback returns error, cleanup ctxs

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3513,7 +3513,7 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
         int rv = tctx->tlsext_ticket_key_cb(s, nctick, nctick + 16,
                                             &ctx, &hctx, 0);
         if (rv < 0)
-            return -1;
+            goto err;
         if (rv == 0)
             return 2;
         if (rv == 2)

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3514,8 +3514,11 @@ static int tls_decrypt_ticket(SSL *s, const unsigned char *etick,
                                             &ctx, &hctx, 0);
         if (rv < 0)
             goto err;
-        if (rv == 0)
+        if (rv == 0) {
+            HMAC_CTX_cleanup(&hctx);
+            EVP_CIPHER_CTX_cleanup(&ctx);
             return 2;
+        }
         if (rv == 2)
             renew_ticket = 1;
     } else {


### PR DESCRIPTION
If application has a TLS ext ticket callback and if the callback returns error while decrypting the ticket the contexts were not cleaned up.

Instead of returning immediately, goto err handles it.

This is taken care in 1.1.0 and in 1.0.2 it is taken care if callback invoked for encryption returns error.